### PR TITLE
[BUGFIX] Fix versions constraints of depending extensions

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -33,8 +33,8 @@ $EM_CONF[$_EXTKEY] = array (
 	'constraints' =>  array(
 		'depends' =>  array(
 			'typo3' => '4.5.0-4.7.99',
-			'extbase' => '1.3.0-1.3.99',
-			'fluid' => '1.3.0-1.3.99',
+			'extbase' => '1.3.0-4.7.99',
+			'fluid' => '1.3.0-4.7.99',
 		),
 		'conflicts' => array(),
 		'suggests' => array(),


### PR DESCRIPTION
This extension is compatible up to TYPO3 4.7.x, but the depending
extensions extbase and fluid were marked to be compatible only for
TYPO3 4.5.x.
Therefore the extension manager warns about the assumed incompatibility
of both extensions during installation in TYPO3 4.6.x or 4.7.x.

This patch fixes the version constraints.
