### PR TITLE
[BUGFIX] Fluid and Extbase compatibility

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -33,8 +33,8 @@ $EM_CONF[$_EXTKEY] = array (
 	'constraints' =>  array(
 		'depends' =>  array(
 			'typo3' => '4.5.0-4.7.99',
-			'extbase' => '1.3.0-1.3.99',
-			'fluid' => '1.3.0-1.3.99',
+			'extbase' => '1.3.0-4.7.99',
+			'fluid' => '1.3.0-4.7.99',
 		),
 		'conflicts' => array(),
 		'suggests' => array(),


### PR DESCRIPTION
The extension declares itself as compatible with TYPO3 CMS
versions 4.5.0 to 4.7.99, but with Fluid and Extbase versions
1.3.0 to 1.3.99. However Fluid and Extebase version for
TYPO3 CMS 4.7x are 4.7.x too. Adjust compatibility ranges to
avoid warnings upon installation.
