### PR TITLE
[Bugfix] namespace line numbering

### DIFF
--- a/Classes/Migrations/Core/RequireOnceInExtensions/Processor.php
+++ b/Classes/Migrations/Core/RequireOnceInExtensions/Processor.php
@@ -100,7 +100,7 @@ class Tx_Smoothmigration_Migrations_Core_RequireOnceInExtensions_Processor exten
 			if ($lineNumber + 1 + $lineOffset != $locationInfo->getLineNumber()) {
 				$newFileContent .= $lineContent;
 			} else {
-				$newLineContent = str_replace($locationInfo->getMatchedString(), '', $lineContent);
+				$newLineContent = str_replace($locationInfo->getMatchedString(), chr(10), $lineContent);
 				if ($newLineContent == $lineContent) {
 					$issue->setMigrationStatus(Tx_Smoothmigration_Domain_Interface_Migration::ERROR_FILE_NOT_CHANGED);
 					$this->messageService->errorMessage($this->ll('migrationsstatus.4'), TRUE);


### PR DESCRIPTION
 if "php typo3/cli_dispatch.phpsh smoothmigration migrate namespace" runs after "php typo3/cli_dispatch.phpsh smoothmigration migrate requireOnce" it gets a lot of errors cause the requireOnce migration changes the line numbers. Replacing the require_once() lines with a newline fixes this
