### PR TITLE
[BUGFIX] XCLASS file resolution for tslib

### DIFF
--- a/Classes/Checks/Core/Xclasses/Processor.php
+++ b/Classes/Checks/Core/Xclasses/Processor.php
@@ -80,12 +80,14 @@ class Tx_Smoothmigration_Checks_Core_Xclasses_Processor extends Tx_Smoothmigrati
 			$physicalLocation
 		);
 
+		// Cut off any possibly leading slash
+		$targetClass = ltrim($targetClass, '/');
 		if(file_exists(PATH_site . 'typo3conf/' . $targetClass)) {
 			$originalFilePath = PATH_site . 'typo3conf/' . $targetClass;
-		} elseif(file_exists(PATH_site . 'typo3/sys' . $targetClass)) {
-			$originalFilePath = PATH_site . 'typo3/sys' . $targetClass;
-		} elseif(file_exists(PATH_site . 'typo3/sysext/cms' . $targetClass)) {
-			$originalFilePath = PATH_site . 'typo3/sysext/cms' . $targetClass;
+		} elseif(file_exists(PATH_site . 'typo3/sys/' . $targetClass)) {
+			$originalFilePath = PATH_site . 'typo3/sys/' . $targetClass;
+		} elseif(file_exists(PATH_site . 'typo3/sysext/cms/' . $targetClass)) {
+			$originalFilePath = PATH_site . 'typo3/sysext/cms/' . $targetClass;
 		} else {
 			$originalFilePath = PATH_site . $targetClass;
 		}


### PR DESCRIPTION
The XCLASS file resolution for eg. tslib/class.tslib_content.php
resolves to PATH_site/tslib/class.tslib_content.php instead of
PATH_site/typo3/sysext/cms/tslib/class.tslib_content.php.
The tslib symlink in document root does not necessarily exist in 4.5.
The file path resolution fails due to a missing slash. Patch is to
always trim left / of given class path and have a ending shlash on
all search directories.